### PR TITLE
Add ability to test unstaged files

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,17 @@
     "dev": "lerna run start --stream --parallel",
     "format": "yarn prettier --write",
     "prettier": "prettier --ignore-path .gitignore \"**/*.+(ts|tsx|json)\"",
-    "test": "lerna run test --"
+    "test": "lerna run test",
+    "test:staged": "git stash -k --include-untracked; yarn test; git stash apply;"
+  },
+  "lint-staged": {
+    "packages/**/*.{ts,js,json,md}": [
+      "prettier --write"
+    ]
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn format && yarn test"
+      "pre-commit": "yarn format && yarn test:staged"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
Includes bash script for testing staged files by:

- stashing all untracked and unstaged files
- performs a yarn test
- after test puts all files back

**Note:** Not perfect. At the time when the files are put back, they show up as merge conflicts.